### PR TITLE
Use a single exit point

### DIFF
--- a/ip6tables_converter.py
+++ b/ip6tables_converter.py
@@ -20,6 +20,8 @@ License:    GNU General Public License version 3 or later
 Have Fun!
 """
 
+from __future__ import print_function
+
 try:
     from collections import UserDict
 except ImportError:
@@ -29,13 +31,8 @@ import re
 import sys
 
 
-class ConverterError():
-    """on accidential case of error show given reason"""
-
-    def __init__(self, message):
-        """message to stdout to compatible testings 2.7 and 3.4"""
-        print (message)
-        sys.exit(1)
+class ConverterError(Exception):
+    pass
 
 
 class Chains(UserDict):
@@ -245,12 +242,8 @@ class Tables(UserDict):
                         self.tblctr += 1
                         self.put_into_tables(line)
             fil0.close()
-        except ValueError as err:
-            print (fname + ": "), err
-            sys.exit(1)
-        except IOError as err:
-            print(fname + ": "), err.strerror
-            sys.exit(1)
+        except (ValueError, IOError) as err:
+            raise ConverterError(str(err))
         if not fname == "reference-one":
             print("# generated from: %s" % (fname))
 
@@ -277,10 +270,13 @@ def main():
         options.sourcefile = "rules"
     sourcefile = options.sourcefile
 
-    chains = Tables(sourcefile, options.sloppy)
-    chains.table_printout()
-
+    try:
+        chains = Tables(sourcefile, options.sloppy)
+        chains.table_printout()
+    except ConverterError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return 0
 
 if __name__ == "__main__":
-    main()
-    sys.exit(0)
+    sys.exit(main())

--- a/ip6tables_converter_tests.py
+++ b/ip6tables_converter_tests.py
@@ -2,8 +2,7 @@
 
 #encoding:utf8
 
-from ip6tables_converter import Chains, Tables, main as haupt
-from mock import patch
+from ip6tables_converter import Chains, Tables, ConverterError, main
 import unittest
 try:
     from StringIO import StringIO
@@ -303,32 +302,16 @@ class Tables_Test(unittest.TestCase):
         Tables 09: read buggy file with shell variables
         """
         expect = "Line 8:"
-        sys_exit_val = False
-        try:
-            with patch('sys.stdout', new=StringIO()) as fake_out:
-                tables = Tables('test-shell-variables')
-        except SystemExit:
-            sys_exit_val = True
-        finally:
-            pass
-        self.assertIn(expect, fake_out.getvalue())
-        self.assertTrue(sys_exit_val)
+        with self.assertRaisesRegexp(ConverterError, expect):
+            Tables('test-shell-variables')
 
     def test_10_shell_functions(self):
         """
         Tables 10: read buggy file with shell functions
         """
         expect = "Line 6:"
-        sys_exit_val = False
-        try:
-            with patch('sys.stdout', new=StringIO()) as fake_out:
-                tables = Tables('test-debian-bug-no-748638')
-        except SystemExit:
-            sys_exit_val = True
-        finally:
-            pass
-        self.assertIn(expect, fake_out.getvalue())
-        self.assertTrue(sys_exit_val)
+        with self.assertRaisesRegexp(ConverterError, expect):
+            Tables('test-debian-bug-no-748638')
 
     def test_11_re6ference_sloppy_one(self):
         """

--- a/iptables_converter.py
+++ b/iptables_converter.py
@@ -20,6 +20,8 @@ License:    GNU General Public License version 3 or later
 Have Fun!
 """
 
+from __future__ import print_function
+
 try:
     from collections import UserDict
 except ImportError:
@@ -29,13 +31,8 @@ import re
 import sys
 
 
-class ConverterError():
-    """on accidential case of error show given reason"""
-
-    def __init__(self, message):
-        """message to stdout to compatible testings 2.7 and 3.4"""
-        print (message)
-        sys.exit(1)
+class ConverterError(Exception):
+    pass
 
 
 class Chains(UserDict):
@@ -245,12 +242,8 @@ class Tables(UserDict):
                         self.tblctr += 1
                         self.put_into_tables(line)
             fil0.close()
-        except ValueError as err:
-            print (fname + ": "), err
-            sys.exit(1)
-        except IOError as err:
-            print(fname + ": "), err.strerror
-            sys.exit(1)
+        except (ValueError, IOError) as err:
+            raise ConverterError(str(err))
         if not fname == "reference-one":
             print("# generated from: %s" % (fname))
 
@@ -277,10 +270,13 @@ def main():
         options.sourcefile = "rules"
     sourcefile = options.sourcefile
 
-    chains = Tables(sourcefile, options.sloppy)
-    chains.table_printout()
-
+    try:
+        chains = Tables(sourcefile, options.sloppy)
+        chains.table_printout()
+    except ConverterError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return 0
 
 if __name__ == "__main__":
-    main()
-    sys.exit(0)
+    sys.exit(main())

--- a/iptables_converter_tests.py
+++ b/iptables_converter_tests.py
@@ -2,8 +2,7 @@
 
 #encoding:utf8
 
-from iptables_converter import Chains, Tables, main as haupt
-from mock import patch
+from iptables_converter import Chains, Tables, ConverterError
 import unittest
 try:
     from StringIO import StringIO
@@ -306,32 +305,16 @@ class Tables_Test(unittest.TestCase):
         Tables 09: read buggy file with shell variables
         """
         expect = "Line 8:"
-        sys_exit_val = False
-        try:
-            with patch('sys.stdout', new=StringIO()) as fake_out:
-                tables = Tables('test-shell-variables')
-        except SystemExit:
-            sys_exit_val = True
-        finally:
-            pass
-        self.assertIn(expect, fake_out.getvalue())
-        self.assertTrue(sys_exit_val)
+        with self.assertRaisesRegexp(ConverterError, expect):
+            Tables('test-shell-variables')
 
     def test_10_shell_functions(self):
         """
         Tables 10: read buggy file with shell functions
         """
         expect = "Line 6:"
-        sys_exit_val = False
-        try:
-            with patch('sys.stdout', new=StringIO()) as fake_out:
-                tables = Tables('test-debian-bug-no-748638')
-        except SystemExit:
-            sys_exit_val = True
-        finally:
-            pass
-        self.assertIn(expect, fake_out.getvalue())
-        self.assertTrue(sys_exit_val)
+        with self.assertRaisesRegexp(ConverterError, expect):
+            Tables('test-debian-bug-no-748638')
 
     def test_11_reference_sloppy_one(self):
         """
@@ -351,6 +334,7 @@ class Tables_Test(unittest.TestCase):
         }
         self.maxDiff = None
         self.assertEqual(expect, tables.data)
+
 
 if __name__ == "__main__":
         unittest.main()


### PR DESCRIPTION
This turns ConverterError into a real exception and stops exiting the program from other places like main() which is a requirement for usage of these classes in other applications (you don't want your whole app to exit abort when importing iptables fails).
    
This will allow us to turn iptables_converter into a module in the future, e.g. for

 https://github.com/apache/cloudstack/pull/2083
